### PR TITLE
Config rework

### DIFF
--- a/cmd/data-aggregation-api/main.go
+++ b/cmd/data-aggregation-api/main.go
@@ -56,7 +56,7 @@ func run() error {
 	// TODO: be able to close goroutine when the context is closed (graceful shutdown)
 	go job.StartBuildLoop(&deviceRepo, &reports)
 
-	router.NewManager(&deviceRepo, &reports).ListenAndServe(ctx, config.Cfg.ListenAddress, config.Cfg.ListenPort)
+	router.NewManager(&deviceRepo, &reports).ListenAndServe(ctx, config.Cfg.API.ListenAddress, config.Cfg.API.ListenPort)
 
 	return nil
 }

--- a/internal/api/router/manager.go
+++ b/internal/api/router/manager.go
@@ -40,9 +40,9 @@ func (m *Manager) ListenAndServe(ctx context.Context, address string, port int) 
 	}()
 
 	tlsConfig := &tls.Config{
-		InsecureSkipVerify: config.Cfg.LdapInsecureSkipVerify, //nolint:gosec // configurable on purpose
+		InsecureSkipVerify: config.Cfg.LDAP.InsecureSkipVerify, //nolint:gosec // configurable on purpose
 	}
-	ldap := auth.NewLDAPAuth(config.Cfg.LdapURL, config.Cfg.LdapBindDN, config.Cfg.LdapPassword, config.Cfg.LdapBaseDN, tlsConfig)
+	ldap := auth.NewLDAPAuth(config.Cfg.LDAP.URL, config.Cfg.LDAP.BindDN, config.Cfg.LDAP.Password, config.Cfg.LDAP.BaseDN, tlsConfig)
 
 	router := httprouter.New()
 

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"strings"
 	"time"
 
 	"github.com/rs/zerolog/log"
@@ -11,6 +12,7 @@ import (
 const (
 	defaultListenAddress = "0.0.0.0"
 	defaultListenPort    = 8080
+	localPath            = "."
 )
 
 var (
@@ -18,42 +20,58 @@ var (
 )
 
 type Config struct {
-	Datacenter             string
-	NetboxURL              string
-	NetboxAPIKey           string
-	LdapURL                string
-	LdapBindDN             string
-	LdapPassword           string
-	LdapBaseDN             string
-	LogLevel               string
-	ListenAddress          string
-	ListenPort             int
-	BuildInterval          time.Duration
-	LdapInsecureSkipVerify bool
-	AllDevicesMustBuild    bool
+	LogLevel   string
+	Datacenter string
+
+	API struct {
+		ListenAddress string
+		ListenPort    int
+	}
+	NetBox struct {
+		URL    string
+		APIKey string
+	}
+	LDAP struct {
+		URL                string
+		BaseDN             string
+		BindDN             string
+		Password           string
+		InsecureSkipVerify bool
+	}
+	Build struct {
+		Interval            time.Duration
+		AllDevicesMustBuild bool
+	}
 }
 
 func setDefaults() {
-	viper.SetDefault("ListenAddress", defaultListenAddress)
-	viper.SetDefault("ListenPort", defaultListenPort)
 	viper.SetDefault("Datacenter", "")
-	viper.SetDefault("NetboxURL", "")
-	viper.SetDefault("NetboxAPIKey", "")
-	viper.SetDefault("BuildInterval", time.Minute)
-	viper.SetDefault("LdapURL", "")
-	viper.SetDefault("LdapBindDN", "")
-	viper.SetDefault("LdapPassword", "")
-	viper.SetDefault("LdapBaseDN", "")
-	viper.SetDefault("LdapInsecureSkipVerify", false)
-	viper.SetDefault("AllDevicesMustBuild", false)
 	viper.SetDefault("LogLevel", "info")
+
+	viper.SetDefault("API.ListenAddress", defaultListenAddress)
+	viper.SetDefault("API.ListenPort", defaultListenPort)
+
+	viper.SetDefault("NetBox.URL", "")
+	viper.SetDefault("NetBox.APIKey", "")
+
+	viper.SetDefault("Build.Interval", time.Minute)
+	viper.SetDefault("Build.AllDevicesMustBuild", false)
+
+	viper.SetDefault("LDAP.URL", "")
+	viper.SetDefault("LDAP.BaseDN", "")
+	viper.SetDefault("LDAP.BindDN", "")
+	viper.SetDefault("LDAP.Password", "")
+	viper.SetDefault("LDAP.InsecureSkipVerify", false)
 }
 
 func LoadConfig() error {
 	viper.SetConfigName("settings")
-	viper.AddConfigPath(".")
+	viper.AddConfigPath(localPath)
 	viper.SetConfigType("yaml")
 	viper.SetEnvPrefix("DAAPI")
+
+	replacer := strings.NewReplacer(".", "_")
+	viper.SetEnvKeyReplacer(replacer)
 
 	setDefaults()
 	viper.AutomaticEnv()

--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -1,10 +1,9 @@
 package config
 
 import (
+	"fmt"
 	"strings"
 	"time"
-
-	"github.com/rs/zerolog/log"
 
 	"github.com/spf13/viper"
 )
@@ -77,7 +76,9 @@ func LoadConfig() error {
 	viper.AutomaticEnv()
 
 	if err := viper.ReadInConfig(); err != nil {
-		log.Error().Err(err).Send()
+		if _, ok := err.(viper.ConfigFileNotFoundError); !ok { //nolint:errorlint  // failing only if invalid file
+			return fmt.Errorf("invalid config file: %w", err)
+		}
 	}
 
 	if err := viper.Unmarshal(&Cfg); err != nil {

--- a/internal/ingestor/netbox/netbox.go
+++ b/internal/ingestor/netbox/netbox.go
@@ -25,7 +25,7 @@ func NewGetRequest(url string) (*http.Request, error) {
 	if err != nil {
 		return nil, err
 	}
-	req.Header.Set("Authorization", "Token "+config.Cfg.NetboxAPIKey)
+	req.Header.Set("Authorization", "Token "+config.Cfg.NetBox.APIKey)
 
 	return req, err
 }
@@ -47,7 +47,7 @@ func Get[R any](endpoint string, out *NetboxResponse[R]) error {
 		datacenterFilter = "&site_group=" + strings.ToUpper(config.Cfg.Datacenter)
 	}
 
-	url := config.Cfg.NetboxURL + endpoint + sep + "limit=0&ordering=id" + datacenterFilter
+	url := config.Cfg.NetBox.URL + endpoint + sep + "limit=0&ordering=id" + datacenterFilter
 	log.Info().Str(endpointKey, endpoint).Msgf("Get %s", url)
 
 	// Get all pages

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -107,7 +107,7 @@ func RunBuild(reportCh chan report.Message) (map[string]*device.Device, report.P
 
 	// We stop here if the user decided all device configuration must have been built with success
 	if precomputeError != nil {
-		if config.Cfg.AllDevicesMustBuild {
+		if config.Cfg.Build.AllDevicesMustBuild {
 			return nil, stats, errors.New("failed: all devices must build")
 		}
 		reportCh <- report.Message{
@@ -162,6 +162,6 @@ func StartBuildLoop(deviceRepo router.DevicesRepository, reports *report.Reposit
 		close(reportCh)
 		wg.Wait()
 
-		time.Sleep(config.Cfg.BuildInterval)
+		time.Sleep(config.Cfg.Build.Interval)
 	}
 }

--- a/settings.example.yaml
+++ b/settings.example.yaml
@@ -1,0 +1,20 @@
+Datacenter: "europe"
+LogLevel: "error"
+
+API:
+  ListenAddress: "127.0.0.1"
+  ListenPort: 1234
+
+LDAP:
+  InsecureSkipVerify: "false"
+  URL: "ldaps://URL.local"
+  BindDN: "cn=<user>,OU=<ou>,DC=<local>"
+  BaseDN: "DC=<local>"
+  Password: "<some_password>"
+
+NetBox:
+  URL: "https://netbox.local"
+  APIKey: "<some_key>"
+
+Build:
+  Interval: "30m"


### PR DESCRIPTION
Fixes LDAP Insecure mode not in Viper:
- this prevented to setup the parameter using the var env
- brings explicit default value to false

The configuration is now hierarchical, making the configuration file easier to read.