### PR TITLE
ci: dependabot compliant with conventional commit

### DIFF
--- a/dependabot.yml
+++ b/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+    - package-ecosystem: "gomod"
+        directory: "/"
+        schedule:
+            interval: "weekly"
+        commit-message:
+            prefix: "build(deps):"
+            include: "scope"


### PR DESCRIPTION
Make dependabot commit compliant with conventional commit.

Before: `Bump X from Y to Z`
After: `build(deps): bump X from Y to Z`

See [dependabot documentation](https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file)