### PR TITLE
remove unused parameters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -256,6 +256,7 @@ linters-settings:
     - name: unreachable-code
     - name: useless-break
     - name: waitgroup-by-value
+    - name: unused-parameter
     severity: error
 
   staticcheck:

--- a/internal/api/router/endpoints.go
+++ b/internal/api/router/endpoints.go
@@ -16,7 +16,7 @@ const applicationJSON = "application/json"
 const hostnameKey = "hostname"
 const wildcard = "*"
 
-func healthCheck(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func healthCheck(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	w.Header().Set(contentType, applicationJSON)
 	fmt.Fprintf(w, `{"status": "ok"}`)
 }
@@ -29,7 +29,7 @@ func prometheusMetrics(h http.Handler) httprouter.Handle {
 
 // getAFKEnabled endpoint returns all AFK enabled devices.
 // They are supposed to be managed by AFK, meaning the configuration should be applied periodically.
-func (m *Manager) getAFKEnabled(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (m *Manager) getAFKEnabled(w http.ResponseWriter, _ *http.Request, ps httprouter.Params) {
 	w.Header().Set(contentType, applicationJSON)
 	hostname := ps.ByName(hostnameKey)
 
@@ -62,7 +62,7 @@ func (m *Manager) getAFKEnabled(w http.ResponseWriter, r *http.Request, ps httpr
 }
 
 // getDeviceOpenConfig endpoint returns OpenConfig JSON for one or all devices.
-func (m *Manager) getDeviceOpenConfig(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
+func (m *Manager) getDeviceOpenConfig(w http.ResponseWriter, _ *http.Request, ps httprouter.Params) {
 	w.Header().Set(contentType, applicationJSON)
 	hostname := ps.ByName(hostnameKey)
 	if ps.ByName(hostnameKey) == wildcard {
@@ -87,7 +87,7 @@ func (m *Manager) getDeviceOpenConfig(w http.ResponseWriter, r *http.Request, ps
 }
 
 // getLastReport returns the last or current report.
-func (m *Manager) getLastReport(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func (m *Manager) getLastReport(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	out, err := m.reports.GetLastJSON()
 	if err != nil {
 		log.Error().Err(err).Send()
@@ -100,7 +100,7 @@ func (m *Manager) getLastReport(w http.ResponseWriter, r *http.Request, _ httpro
 }
 
 // getLastCompleteReport returns the previous build report.
-func (m *Manager) getLastCompleteReport(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func (m *Manager) getLastCompleteReport(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	out, err := m.reports.GetLastCompleteJSON()
 	if err != nil {
 		log.Error().Err(err).Send()
@@ -113,7 +113,7 @@ func (m *Manager) getLastCompleteReport(w http.ResponseWriter, r *http.Request, 
 }
 
 // getLastSuccessfulReport returns the previous successful build report.
-func (m *Manager) getLastSuccessfulReport(w http.ResponseWriter, r *http.Request, _ httprouter.Params) {
+func (m *Manager) getLastSuccessfulReport(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	out, err := m.reports.GetLastSuccessfulJSON()
 	if err != nil {
 		log.Error().Err(err).Send()

--- a/internal/convertor/device/device.go
+++ b/internal/convertor/device/device.go
@@ -106,7 +106,7 @@ func (d *Device) GenerateOpenconfig() error {
 		return fmt.Errorf("convert from BGP to OpenConfig failed: %w", err)
 	}
 
-	routingPolicyConfig, err := rpconvertors.RoutingPolicyToOpenconfig(d.Dcim.Hostname, d.PrefixLists, d.CommunityLists, d.RoutePolicies)
+	routingPolicyConfig, err := rpconvertors.RoutingPolicyToOpenconfig(d.PrefixLists, d.CommunityLists, d.RoutePolicies)
 	if err != nil {
 		return fmt.Errorf("convert from Routing Policy to OpenConfig failed: %w", err)
 	}

--- a/internal/convertor/routingpolicy/community_set.go
+++ b/internal/convertor/routingpolicy/community_set.go
@@ -16,7 +16,7 @@ func extractCommunityListTerms(communityList *routingpolicy.CommunityList) []ope
 
 // CommunityListToOpenconfig converts precomputed prefix-lists to OpenConfig.
 // OpenConfig path: /routing-policy/defined-sets/bgp-defined-sets/community-sets/.
-func CommunityListToOpenconfig(hostname string, communityLists []*routingpolicy.CommunityList) map[string]*openconfig.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet {
+func CommunityListToOpenconfig(communityLists []*routingpolicy.CommunityList) map[string]*openconfig.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet {
 	var communitySets = make(map[string]*openconfig.RoutingPolicy_DefinedSets_BgpDefinedSets_CommunitySet)
 
 	for _, communityList := range communityLists {

--- a/internal/convertor/routingpolicy/prefix_set.go
+++ b/internal/convertor/routingpolicy/prefix_set.go
@@ -63,7 +63,7 @@ func extractPrefixListTerms(terms []*routingpolicy.PrefixListTerm) map[openconfi
 
 // PrefixListsToOpenconfig converts precomputed prefix-lists to OpenConfig.
 // OpenConfig path: /routing-policy/defined-sets/prefix-sets/.
-func PrefixListsToOpenconfig(hostname string, prefixLists []*routingpolicy.PrefixList) map[string]*openconfig.RoutingPolicy_DefinedSets_PrefixSet {
+func PrefixListsToOpenconfig(prefixLists []*routingpolicy.PrefixList) map[string]*openconfig.RoutingPolicy_DefinedSets_PrefixSet {
 	prefixSets := make(map[string]*openconfig.RoutingPolicy_DefinedSets_PrefixSet)
 
 	for _, prefixList := range prefixLists {

--- a/internal/convertor/routingpolicy/routing_policy.go
+++ b/internal/convertor/routingpolicy/routing_policy.go
@@ -7,7 +7,7 @@ import (
 
 // RoutingPolicyToOpenconfig converts all precomputed assets in routing-policy/* to OpenConfig.
 // OpenConfig path: /routing-policy/.
-func RoutingPolicyToOpenconfig(hostname string, prefixLists []*routingpolicy.PrefixList, communityLists []*routingpolicy.CommunityList, routePolicies []*routingpolicy.RoutePolicy) (*openconfig.RoutingPolicy, error) {
+func RoutingPolicyToOpenconfig(prefixLists []*routingpolicy.PrefixList, communityLists []*routingpolicy.CommunityList, routePolicies []*routingpolicy.RoutePolicy) (*openconfig.RoutingPolicy, error) {
 	policies, err := RoutePoliciesToOpenconfig(routePolicies)
 	if err != nil {
 		return nil, err
@@ -16,9 +16,9 @@ func RoutingPolicyToOpenconfig(hostname string, prefixLists []*routingpolicy.Pre
 	routingPolicy := openconfig.RoutingPolicy{
 		PolicyDefinition: policies,
 		DefinedSets: &openconfig.RoutingPolicy_DefinedSets{
-			PrefixSet: PrefixListsToOpenconfig(hostname, prefixLists),
+			PrefixSet: PrefixListsToOpenconfig(prefixLists),
 			BgpDefinedSets: &openconfig.RoutingPolicy_DefinedSets_BgpDefinedSets{
-				CommunitySet: CommunityListToOpenconfig(hostname, communityLists),
+				CommunitySet: CommunityListToOpenconfig(communityLists),
 			},
 		},
 	}

--- a/internal/convertor/routingpolicy/routing_policy_test.go
+++ b/internal/convertor/routingpolicy/routing_policy_test.go
@@ -256,7 +256,7 @@ func TestRoutingPolicyToOpenconfig(t *testing.T) {
 		},
 	}
 
-	ret, err := routingpolicy.RoutingPolicyToOpenconfig("tor01-01", prefixLists, communityLists, routingPolicies)
+	ret, err := routingpolicy.RoutingPolicyToOpenconfig(prefixLists, communityLists, routingPolicies)
 	if err != nil {
 		t.Errorf("failed to convert routing policies to OpenConfig")
 	}


### PR DESCRIPTION
This check is not enabled by default in Revive configuration.