### PR TITLE
refactor!: enabled field is now used to shut or no shut the session

### DIFF
--- a/internal/convertor/bgp/bgp_test.go
+++ b/internal/convertor/bgp/bgp_test.go
@@ -49,7 +49,6 @@ func TestBGPToOpenConfig(t *testing.T) {
 
 	sessions := []*cmdbBGP.Session{
 		{
-			Status: "active",
 			PeerA: cmdbBGP.DeviceSession{
 				Device: struct {
 					Name string `json:"name" validate:"required"`
@@ -92,6 +91,7 @@ func TestBGPToOpenConfig(t *testing.T) {
 				Description:     "TO:SPINE01-01",
 				MaximumPrefixes: 128,
 				EnforceFirstAs:  true,
+				Enabled:         true,
 			},
 			PeerB: cmdbBGP.DeviceSession{
 				Device: struct {
@@ -135,6 +135,7 @@ func TestBGPToOpenConfig(t *testing.T) {
 				Description:     "TO:TOR01-01",
 				MaximumPrefixes: 10,
 				EnforceFirstAs:  true,
+				Enabled:         true,
 			},
 			Password: awesomePassword,
 		},

--- a/internal/convertor/bgp/neighbor.go
+++ b/internal/convertor/bgp/neighbor.go
@@ -29,7 +29,6 @@ func NeighborsToOpenconfig(hostname string, sessions []*bgp.Session) (map[string
 	for _, session := range sessions {
 		localInfo, remoteInfo := getBGPsides(hostname, session)
 
-		active := session.Status == bgp.StatusActive
 		neighborAddress := remoteInfo.LocalAddress.Address.IP.String()
 
 		policy := openconfig.NetworkInstance_Protocol_Bgp_Neighbor_ApplyPolicy{}
@@ -50,7 +49,7 @@ func NeighborsToOpenconfig(hostname string, sessions []*bgp.Session) (map[string
 			NeighborAddress: &neighborAddress,
 			ApplyPolicy:     &policy,
 			AfiSafi:         safis,
-			Enabled:         &active,
+			Enabled:         &localInfo.Enabled,
 			PeerAs:          remoteInfo.LocalAsn.Number,
 			LocalAs:         localInfo.LocalAsn.Number,
 			AuthPassword:    &session.Password,

--- a/internal/ingestor/cmdb/bgp_session_test.go
+++ b/internal/ingestor/cmdb/bgp_session_test.go
@@ -26,6 +26,7 @@ const ipv4BGPSession = `
         "id": 1,
         "peer_a": {
             "id": 1,
+			"enabled": true,
             "local_address": {
                 "id": 1,
                 "url": "http://127.0.0.1:8001/api/ipam/ip-addresses/1/",
@@ -77,6 +78,7 @@ const ipv4BGPSession = `
         },
         "peer_b": {
             "id": 2,
+			"enabled": false,
             "local_address": {
                 "id": 2,
                 "url": "http://127.0.0.1:8001/api/ipam/ip-addresses/2/",
@@ -131,7 +133,6 @@ const ipv4BGPSession = `
 var ipv4Ingested = map[string][]*bgp.Session{
 	"tor01-01": {
 		&bgp.Session{
-			Status: "active",
 			PeerA: bgp.DeviceSession{
 				Device: struct {
 					Name string `json:"name" validate:"required"`
@@ -174,6 +175,7 @@ var ipv4Ingested = map[string][]*bgp.Session{
 				Description:     "TO:SPINE01-01",
 				MaximumPrefixes: 128,
 				EnforceFirstAs:  true,
+				Enabled:         true,
 			},
 			PeerB: bgp.DeviceSession{
 				Device: struct {
@@ -211,13 +213,13 @@ var ipv4Ingested = map[string][]*bgp.Session{
 				Description:     "TO:TOR01-01",
 				MaximumPrefixes: 10,
 				EnforceFirstAs:  true,
+				Enabled:         false,
 			},
 			Password: "awesomepassword",
 		},
 	},
 	"spine01-01": {
 		&bgp.Session{
-			Status: "active",
 			PeerA: bgp.DeviceSession{
 				Device: struct {
 					Name string `json:"name" validate:"required"`
@@ -260,6 +262,7 @@ var ipv4Ingested = map[string][]*bgp.Session{
 				Description:     "TO:SPINE01-01",
 				MaximumPrefixes: 128,
 				EnforceFirstAs:  true,
+				Enabled:         true,
 			},
 			PeerB: bgp.DeviceSession{
 				Device: struct {
@@ -297,6 +300,7 @@ var ipv4Ingested = map[string][]*bgp.Session{
 				Description:     "TO:TOR01-01",
 				MaximumPrefixes: 10,
 				EnforceFirstAs:  true,
+				Enabled:         false,
 			},
 			Password: "awesomepassword",
 		},
@@ -313,6 +317,7 @@ const ipv6BGPSession = `
 		"id": 2,
 		"peer_a": {
 			"id": 3,
+			"enabled": true,
 			"local_address": {
 				"id": 3,
 				"url": "http://127.0.0.1:8001/api/ipam/ip-addresses/3/",
@@ -356,6 +361,7 @@ const ipv6BGPSession = `
 		},
 		"peer_b": {
 			"id": 4,
+			"enabled": true,
 			"local_address": {
 				"id": 4,
 				"url": "http://127.0.0.1:8001/api/ipam/ip-addresses/4/",
@@ -410,7 +416,6 @@ const ipv6BGPSession = `
 var ipv6Ingested = map[string][]*bgp.Session{
 	"tor01-01": {
 		&bgp.Session{
-			Status: "active",
 			PeerA: bgp.DeviceSession{
 				Device: struct {
 					Name string `json:"name" validate:"required"`
@@ -449,6 +454,7 @@ var ipv6Ingested = map[string][]*bgp.Session{
 				Description:     "TO:SPINE01-01:V6",
 				MaximumPrefixes: 0,
 				EnforceFirstAs:  true,
+				Enabled:         true,
 			},
 			PeerB: bgp.DeviceSession{
 				Device: struct {
@@ -488,13 +494,13 @@ var ipv6Ingested = map[string][]*bgp.Session{
 				Description:     "TO:TOR01-01:V6",
 				MaximumPrefixes: 0,
 				EnforceFirstAs:  true,
+				Enabled:         true,
 			},
 			Password: "awesomepassword",
 		},
 	},
 	"spine01-01": {
 		&bgp.Session{
-			Status: "active",
 			PeerA: bgp.DeviceSession{
 				Device: struct {
 					Name string `json:"name" validate:"required"`
@@ -533,6 +539,7 @@ var ipv6Ingested = map[string][]*bgp.Session{
 				Description:     "TO:SPINE01-01:V6",
 				MaximumPrefixes: 0,
 				EnforceFirstAs:  true,
+				Enabled:         true,
 			},
 			PeerB: bgp.DeviceSession{
 				Device: struct {
@@ -572,6 +579,7 @@ var ipv6Ingested = map[string][]*bgp.Session{
 				Description:     "TO:TOR01-01:V6",
 				MaximumPrefixes: 0,
 				EnforceFirstAs:  true,
+				Enabled:         true,
 			},
 			Password: "awesomepassword",
 		},

--- a/internal/model/cmdb/bgp/session.go
+++ b/internal/model/cmdb/bgp/session.go
@@ -6,15 +6,6 @@ import (
 	"github.com/criteo/data-aggregation-api/internal/types"
 )
 
-type SessionStatus string
-
-const (
-	StatusActive      SessionStatus = "active"
-	StatusPlanned     SessionStatus = "planned"
-	StatusMaintenance SessionStatus = "maintenance"
-	StatusOffline     SessionStatus = "offline"
-)
-
 type Address struct {
 	Address types.CIDR `json:"address" validate:"required"`
 	Family  int        `json:"family"  validate:"required"`
@@ -34,10 +25,10 @@ type DeviceSession struct {
 	LocalAddress    Address                        `json:"local_address"    validate:"required"`
 	MaximumPrefixes uint32                         `json:"maximum_prefixes" validate:"omitempty"`
 	EnforceFirstAs  bool                           `json:"enforce_first_as" validate:"omitempty"`
+	Enabled         bool                           `json:"enabled"   validate:"required"`
 }
 
 type Session struct {
-	Status   SessionStatus `json:"status"   validate:"required"`
 	Password string        `json:"password" validate:"omitempty"`
 	PeerA    DeviceSession `json:"peer_a"   validate:"required"`
 	PeerB    DeviceSession `json:"peer_b"   validate:"required"`


### PR DESCRIPTION
"status" is now "enabled" to reflect the change on CMDB side: https://github.com/criteo/netbox-network-cmdb/pull/15