### PR TITLE
fix(bgp): peers cannot be shutdown

### DIFF
--- a/internal/convertor/bgp/bgp_test.go
+++ b/internal/convertor/bgp/bgp_test.go
@@ -91,7 +91,7 @@ func TestBGPToOpenConfig(t *testing.T) {
 				Description:     "TO:SPINE01-01",
 				MaximumPrefixes: 128,
 				EnforceFirstAs:  true,
-				Enabled:         true,
+				Enabled:         &flagTrue,
 			},
 			PeerB: cmdbBGP.DeviceSession{
 				Device: struct {
@@ -135,7 +135,7 @@ func TestBGPToOpenConfig(t *testing.T) {
 				Description:     "TO:TOR01-01",
 				MaximumPrefixes: 10,
 				EnforceFirstAs:  true,
-				Enabled:         true,
+				Enabled:         &flagTrue,
 			},
 			Password: awesomePassword,
 		},

--- a/internal/convertor/bgp/neighbor.go
+++ b/internal/convertor/bgp/neighbor.go
@@ -49,7 +49,7 @@ func NeighborsToOpenconfig(hostname string, sessions []*bgp.Session) (map[string
 			NeighborAddress: &neighborAddress,
 			ApplyPolicy:     &policy,
 			AfiSafi:         safis,
-			Enabled:         &localInfo.Enabled,
+			Enabled:         localInfo.Enabled,
 			PeerAs:          remoteInfo.LocalAsn.Number,
 			LocalAs:         localInfo.LocalAsn.Number,
 			AuthPassword:    &session.Password,

--- a/internal/ingestor/cmdb/bgp_session_test.go
+++ b/internal/ingestor/cmdb/bgp_session_test.go
@@ -15,6 +15,8 @@ import (
 
 var as65000 uint32 = 65000
 var as65001 uint32 = 65001
+var flagTrue = true
+var flagFalse = false
 
 /*
 	BGP session - IPv4
@@ -175,7 +177,7 @@ var ipv4Ingested = map[string][]*bgp.Session{
 				Description:     "TO:SPINE01-01",
 				MaximumPrefixes: 128,
 				EnforceFirstAs:  true,
-				Enabled:         true,
+				Enabled:         &flagTrue,
 			},
 			PeerB: bgp.DeviceSession{
 				Device: struct {
@@ -213,7 +215,7 @@ var ipv4Ingested = map[string][]*bgp.Session{
 				Description:     "TO:TOR01-01",
 				MaximumPrefixes: 10,
 				EnforceFirstAs:  true,
-				Enabled:         false,
+				Enabled:         &flagFalse,
 			},
 			Password: "awesomepassword",
 		},
@@ -262,7 +264,7 @@ var ipv4Ingested = map[string][]*bgp.Session{
 				Description:     "TO:SPINE01-01",
 				MaximumPrefixes: 128,
 				EnforceFirstAs:  true,
-				Enabled:         true,
+				Enabled:         &flagTrue,
 			},
 			PeerB: bgp.DeviceSession{
 				Device: struct {
@@ -300,7 +302,7 @@ var ipv4Ingested = map[string][]*bgp.Session{
 				Description:     "TO:TOR01-01",
 				MaximumPrefixes: 10,
 				EnforceFirstAs:  true,
-				Enabled:         false,
+				Enabled:         &flagFalse,
 			},
 			Password: "awesomepassword",
 		},
@@ -454,7 +456,7 @@ var ipv6Ingested = map[string][]*bgp.Session{
 				Description:     "TO:SPINE01-01:V6",
 				MaximumPrefixes: 0,
 				EnforceFirstAs:  true,
-				Enabled:         true,
+				Enabled:         &flagTrue,
 			},
 			PeerB: bgp.DeviceSession{
 				Device: struct {
@@ -494,7 +496,7 @@ var ipv6Ingested = map[string][]*bgp.Session{
 				Description:     "TO:TOR01-01:V6",
 				MaximumPrefixes: 0,
 				EnforceFirstAs:  true,
-				Enabled:         true,
+				Enabled:         &flagTrue,
 			},
 			Password: "awesomepassword",
 		},
@@ -539,7 +541,7 @@ var ipv6Ingested = map[string][]*bgp.Session{
 				Description:     "TO:SPINE01-01:V6",
 				MaximumPrefixes: 0,
 				EnforceFirstAs:  true,
-				Enabled:         true,
+				Enabled:         &flagTrue,
 			},
 			PeerB: bgp.DeviceSession{
 				Device: struct {
@@ -579,7 +581,7 @@ var ipv6Ingested = map[string][]*bgp.Session{
 				Description:     "TO:TOR01-01:V6",
 				MaximumPrefixes: 0,
 				EnforceFirstAs:  true,
-				Enabled:         true,
+				Enabled:         &flagTrue,
 			},
 			Password: "awesomepassword",
 		},

--- a/internal/model/cmdb/bgp/session.go
+++ b/internal/model/cmdb/bgp/session.go
@@ -21,11 +21,11 @@ type DeviceSession struct {
 	RoutePolicyIn   *routingpolicy.RoutePolicyLite `json:"route_policy_in"  validate:"omitempty"`
 	RoutePolicyOut  *routingpolicy.RoutePolicyLite `json:"route_policy_out" validate:"omitempty"`
 	AfiSafis        []*AfiSafi                     `json:"afi_safis"        validate:"required"`
+	Enabled         *bool                          `json:"enabled"          validate:"required"`
 	Description     string                         `json:"description"      validate:"omitempty"`
 	LocalAddress    Address                        `json:"local_address"    validate:"required"`
 	MaximumPrefixes uint32                         `json:"maximum_prefixes" validate:"omitempty"`
 	EnforceFirstAs  bool                           `json:"enforce_first_as" validate:"omitempty"`
-	Enabled         bool                           `json:"enabled"   validate:"required"`
 }
 
 type Session struct {


### PR DESCRIPTION
Forgot to use a pointer in the structure, making Validate package to disallow False values for "DeviceBGPSession.enabled".