### PR TITLE
Remove Prefix/Community list sequences

### DIFF
--- a/internal/convertor/routingpolicy/routing_policy_test.go
+++ b/internal/convertor/routingpolicy/routing_policy_test.go
@@ -72,11 +72,9 @@ func TestRoutingPolicyToOpenconfig(t *testing.T) {
 			},
 			Terms: []*cmdbRP.CommunityListTerm{
 				{
-					Sequence:  10,
 					Community: "650..:999",
 				},
 				{
-					Sequence:  20,
 					Community: "650..:1000",
 				},
 			},

--- a/internal/convertor/routingpolicy/routing_policy_test.go
+++ b/internal/convertor/routingpolicy/routing_policy_test.go
@@ -38,7 +38,6 @@ func TestRoutingPolicyToOpenconfig(t *testing.T) {
 			},
 			Terms: []*cmdbRP.PrefixListTerm{
 				{
-					Sequence: 10,
 					Prefix: types.CIDR{
 						IP: net.IP{
 							0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 0, 2, 0,
@@ -49,7 +48,6 @@ func TestRoutingPolicyToOpenconfig(t *testing.T) {
 					GreaterOrEqual: 0,
 				},
 				{
-					Sequence: 20,
 					Prefix: types.CIDR{
 						IP: net.IP{
 							0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 0, 2, 16,

--- a/internal/ingestor/cmdb/community_list_test.go
+++ b/internal/ingestor/cmdb/community_list_test.go
@@ -27,11 +27,9 @@ func TestPrecomputeCommunityLists(t *testing.T) {
 					},
 					"terms": [
 						{
-							"sequence": 10,
 							"community": "650..:999"
 						},
 						{
-							"sequence": 20,
 							"community": "650..:1000"
 						}
 					],
@@ -52,11 +50,9 @@ func TestPrecomputeCommunityLists(t *testing.T) {
 						},
 						Terms: []*routingpolicy.CommunityListTerm{
 							{
-								Sequence:  10,
 								Community: "650..:999",
 							},
 							{
-								Sequence:  20,
 								Community: "650..:1000",
 							},
 						},

--- a/internal/ingestor/cmdb/prefix_list_test.go
+++ b/internal/ingestor/cmdb/prefix_list_test.go
@@ -31,13 +31,11 @@ func TestPrecomputePrefixLists(t *testing.T) {
 					"ip_version": "ipv4",
 					"terms": [
 						{
-							"sequence": 10,
 							"prefix": "192.0.2.0/28",
 							"le": null,
 							"ge": null
 						},
 						{
-							"sequence": 20,
 							"prefix": "192.0.2.16/28",
 							"le": 32,
 							"ge": 30
@@ -57,7 +55,6 @@ func TestPrecomputePrefixLists(t *testing.T) {
 						},
 						Terms: []*routingpolicy.PrefixListTerm{
 							{
-								Sequence: 10,
 								Prefix: types.CIDR{
 									IP: net.IP{
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 0, 2, 0,
@@ -68,7 +65,6 @@ func TestPrecomputePrefixLists(t *testing.T) {
 								GreaterOrEqual: 0,
 							},
 							{
-								Sequence: 20,
 								Prefix: types.CIDR{
 									IP: net.IP{
 										0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 255, 255, 192, 0, 2, 16,

--- a/internal/model/cmdb/routingpolicy/community_list.go
+++ b/internal/model/cmdb/routingpolicy/community_list.go
@@ -2,7 +2,6 @@ package routingpolicy
 
 type CommunityListTerm struct {
 	Community string `json:"community" validate:"required"`
-	Sequence  int    `json:"sequence"  validate:"required"`
 }
 
 type CommunityList struct {

--- a/internal/model/cmdb/routingpolicy/prefix_list.go
+++ b/internal/model/cmdb/routingpolicy/prefix_list.go
@@ -13,7 +13,6 @@ const (
 
 type PrefixListTerm struct {
 	Prefix         types.CIDR `json:"prefix"   validate:"required"`
-	Sequence       int        `json:"sequence" validate:"required"`
 	LessOrEqual    int        `json:"le"       validate:"omitempty"`
 	GreaterOrEqual int        `json:"ge"       validate:"omitempty"`
 }


### PR DESCRIPTION
In OpenConfig, Prefix/Community lists are set.
The user order is not kept, and the sequence is not defined.