### PR TITLE
feat(metrics): build durations

### DIFF
--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -157,8 +157,10 @@ func StartBuildLoop(deviceRepo router.DevicesRepository, reports *report.Reposit
 			reports.Watch(reportCh)
 		}()
 
+		// Start the build
 		reports.UpdateStatus(report.InProgress)
-		if devs, stats, err := RunBuild(reportCh); err != nil {
+		devs, stats, err := RunBuild(reportCh)
+		if err != nil {
 			metricsRegistry.BuildFailed()
 
 			reports.UpdateStatus(report.Failed)
@@ -177,6 +179,11 @@ func StartBuildLoop(deviceRepo router.DevicesRepository, reports *report.Reposit
 
 			log.Info().Msg("build successful")
 		}
+
+		metricsRegistry.SetBuildDataFetchingDuration(stats.Performance.DataFetchingDuration.Seconds())
+		metricsRegistry.SetBuildPrecomputeDuration(stats.Performance.PrecomputeDuration.Seconds())
+		metricsRegistry.SetBuildComputeDuration(stats.Performance.ComputeDuration.Seconds())
+		metricsRegistry.SetBuildTotalDuration(stats.Performance.BuildDuration.Seconds())
 
 		reports.MarkAsComplete()
 		close(reportCh)

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -7,7 +7,7 @@ import (
 )
 
 type Registry struct {
-	AppInfo            *prometheus.GaugeVec
+	appInfo            *prometheus.GaugeVec
 	buildTotal         *prometheus.CounterVec
 	BuiltDevicesNumber prometheus.Gauge
 	lastBuildStatus    prometheus.Gauge
@@ -29,7 +29,7 @@ func NewRegistry() Registry {
 	appInfo.WithLabelValues(app.Info.Version, app.Info.Commit, app.Info.BuildTime, app.Info.BuildUser).Set(1)
 
 	return Registry{
-		AppInfo: appInfo,
+		appInfo: appInfo,
 		BuiltDevicesNumber: promauto.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "built_devices_number",

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -11,6 +11,11 @@ type Registry struct {
 	BuiltDevicesNumber *prometheus.GaugeVec
 	lastBuildStatus    *prometheus.GaugeVec
 	buildTotal         *prometheus.CounterVec
+
+	buildTotalDuration        prometheus.Gauge
+	buildDataFetchingDuration prometheus.Gauge
+	buildPrecomputeDuration   prometheus.Gauge
+	buildComputeDuration      prometheus.Gauge
 }
 
 func NewRegistry() Registry {
@@ -40,13 +45,36 @@ func NewRegistry() Registry {
 			},
 			[]string{},
 		),
-
 		buildTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
 				Name: "completed_build_total",
 				Help: "Total number of completed build",
 			},
 			[]string{"success"},
+		),
+		buildTotalDuration: promauto.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "build_total_duration_seconds",
+				Help: "Total duration of the build",
+			},
+		),
+		buildDataFetchingDuration: promauto.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "build_data_fetching_duration_seconds",
+				Help: "Duration of the data fetching step",
+			},
+		),
+		buildPrecomputeDuration: promauto.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "build_precompute_duration_seconds",
+				Help: "Duration of the precompute step",
+			},
+		),
+		buildComputeDuration: promauto.NewGauge(
+			prometheus.GaugeOpts{
+				Name: "build_compute_duration_seconds",
+				Help: "Duration of the compute step",
+			},
 		),
 	}
 }
@@ -72,4 +100,24 @@ func (r *Registry) BuildFailed() {
 // SetBuiltDevices updates the `built_devices` gauge.
 func (r *Registry) SetBuiltDevices(count uint32) {
 	r.BuiltDevicesNumber.WithLabelValues().Set(float64(count))
+}
+
+// SetBuildTotalDuration updates the `build_total_duration_seconds` gauge.
+func (r *Registry) SetBuildTotalDuration(duration float64) {
+	r.buildTotalDuration.Set(duration)
+}
+
+// SetBuildDataFetchingDuration updates the `build_data_fetching_duration_seconds` gauge.
+func (r *Registry) SetBuildDataFetchingDuration(duration float64) {
+	r.buildDataFetchingDuration.Set(duration)
+}
+
+// SetBuildPrecomputeDuration updates the `build_precompute_duration_seconds` gauge.
+func (r *Registry) SetBuildPrecomputeDuration(duration float64) {
+	r.buildPrecomputeDuration.Set(duration)
+}
+
+// SetBuildComputeDuration updates the `build_compute_duration_seconds` gauge.
+func (r *Registry) SetBuildComputeDuration(duration float64) {
+	r.buildComputeDuration.Set(duration)
 }

--- a/internal/metrics/registry.go
+++ b/internal/metrics/registry.go
@@ -8,9 +8,9 @@ import (
 
 type Registry struct {
 	AppInfo            *prometheus.GaugeVec
-	BuiltDevicesNumber *prometheus.GaugeVec
-	lastBuildStatus    *prometheus.GaugeVec
 	buildTotal         *prometheus.CounterVec
+	BuiltDevicesNumber prometheus.Gauge
+	lastBuildStatus    prometheus.Gauge
 
 	buildTotalDuration        prometheus.Gauge
 	buildDataFetchingDuration prometheus.Gauge
@@ -30,20 +30,18 @@ func NewRegistry() Registry {
 
 	return Registry{
 		AppInfo: appInfo,
-		BuiltDevicesNumber: promauto.NewGaugeVec(
+		BuiltDevicesNumber: promauto.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "built_devices_number",
 				Help: "Number of devices built during last successful build",
 			},
-			[]string{},
 		),
 
-		lastBuildStatus: promauto.NewGaugeVec(
+		lastBuildStatus: promauto.NewGauge(
 			prometheus.GaugeOpts{
 				Name: "build_status",
 				Help: "Last completed build status, 0=Failed, 1=Success",
 			},
-			[]string{},
 		),
 		buildTotal: promauto.NewCounterVec(
 			prometheus.CounterOpts{
@@ -84,7 +82,7 @@ func NewRegistry() Registry {
 // `build_status` counter is set to 1.
 // `completed_build_total` increases with success label set to true.
 func (r *Registry) BuildSuccessful() {
-	r.lastBuildStatus.WithLabelValues().Set(1)
+	r.lastBuildStatus.Set(1)
 	r.buildTotal.WithLabelValues("true").Inc()
 }
 
@@ -93,13 +91,13 @@ func (r *Registry) BuildSuccessful() {
 // `build_status` counter is set to 0.
 // `completed_build_total` increases with success label set to false.
 func (r *Registry) BuildFailed() {
-	r.lastBuildStatus.WithLabelValues().Set(0)
+	r.lastBuildStatus.Set(0)
 	r.buildTotal.WithLabelValues("false").Inc()
 }
 
 // SetBuiltDevices updates the `built_devices` gauge.
 func (r *Registry) SetBuiltDevices(count uint32) {
-	r.BuiltDevicesNumber.WithLabelValues().Set(float64(count))
+	r.BuiltDevicesNumber.Set(float64(count))
 }
 
 // SetBuildTotalDuration updates the `build_total_duration_seconds` gauge.


### PR DESCRIPTION
Expose the following build stats as Prometheus metrics:
- total duration
- duration for each steps (data fetching, precompute, compute)

Also includes minor changes:
- simple gauge when no labels
- "appInfo" attribute is now private