### PR TITLE
fix: panic when user requests non built config

### DIFF
--- a/internal/convertor/device/serializer.go
+++ b/internal/convertor/device/serializer.go
@@ -88,6 +88,10 @@ func (s *SafeRepository) GetDeviceOpenConfigJSON(hostname string) ([]byte, error
 	defer s.mutex.Unlock()
 
 	if dev, ok := s.devices[hostname]; ok {
+		if dev == nil {
+			return []byte(emptyJSON), errors.New("build failed for this device")
+		}
+
 		var config json.RawMessage
 		var err error
 		out := bytes.NewBuffer(nil)


### PR DESCRIPTION
When a device fails to build, the pointer to the device is a nil pointer.

When an user was requesting the configuration of a device which never built successfully, a panic occured.
Now it returns a 500 error with an empty dict.