### PR TITLE
feat(api): request to start a new build

### DIFF
--- a/cmd/data-aggregation-api/main.go
+++ b/cmd/data-aggregation-api/main.go
@@ -40,7 +40,7 @@ var (
 	builtBy = "unknown"
 )
 
-func dispatchSingleRequest(incoming chan struct{}) chan bool {
+func dispatchSingleRequest(incoming <-chan struct{}) chan bool {
 	outgoing := make(chan bool)
 
 	go func() {

--- a/cmd/data-aggregation-api/main.go
+++ b/cmd/data-aggregation-api/main.go
@@ -40,14 +40,14 @@ var (
 	builtBy = "unknown"
 )
 
-func dispatchSingleRequest(incoming <-chan struct{}) chan bool {
-	outgoing := make(chan bool)
+func dispatchSingleRequest(incoming <-chan struct{}) chan struct{} {
+	outgoing := make(chan struct{})
 
 	go func() {
 		defer close(outgoing)
 		for range incoming {
 			log.Info().Msg("Received new build request.")
-			outgoing <- true
+			outgoing <- struct{}{}
 		}
 	}()
 

--- a/internal/api/router/endpoints.go
+++ b/internal/api/router/endpoints.go
@@ -137,7 +137,7 @@ func (m *Manager) getLastSuccessfulReport(w http.ResponseWriter, _ *http.Request
 func (m *Manager) triggerBuild(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
 	w.Header().Set(contentType, applicationJSON)
 	select {
-	case m.restartRequest <- struct{}{}:
+	case m.newBuildRequest <- struct{}{}:
 		_, _ = w.Write([]byte("{\"message\": \"new build request received\""))
 	default:
 		_, _ = w.Write([]byte("{\"message\": \"a build request is already pending\""))

--- a/internal/api/router/endpoints.go
+++ b/internal/api/router/endpoints.go
@@ -130,3 +130,16 @@ func (m *Manager) getLastSuccessfulReport(w http.ResponseWriter, _ *http.Request
 	w.Header().Set(contentType, applicationJSON)
 	_, _ = w.Write(out)
 }
+
+// triggerBuild enables the user to trigger a new build.
+//
+// It only accepts one build request at a time.
+func (m *Manager) triggerBuild(w http.ResponseWriter, _ *http.Request, _ httprouter.Params) {
+	w.Header().Set(contentType, applicationJSON)
+	select {
+	case m.restartRequest <- struct{}{}:
+		_, _ = w.Write([]byte("{\"message\": \"new build request received\""))
+	default:
+		_, _ = w.Write([]byte("{\"message\": \"a build request is already pending\""))
+	}
+}

--- a/internal/api/router/manager.go
+++ b/internal/api/router/manager.go
@@ -27,20 +27,20 @@ type DevicesRepository interface {
 }
 
 type Manager struct {
-	devices        DevicesRepository
-	reports        *report.Repository
-	restartRequest chan<- struct{}
+	devices         DevicesRepository
+	reports         *report.Repository
+	newBuildRequest chan<- struct{}
 }
 
 // NewManager creates and initializes a new API manager.
 func NewManager(deviceRepo DevicesRepository, reports *report.Repository, restartRequest chan<- struct{}) *Manager {
-	return &Manager{devices: deviceRepo, reports: reports, restartRequest: restartRequest}
+	return &Manager{devices: deviceRepo, reports: reports, newBuildRequest: restartRequest}
 }
 
 // ListenAndServe starts to serve Web API requests.
 func (m *Manager) ListenAndServe(ctx context.Context, address string, port int) error {
 	defer func() {
-		close(m.restartRequest)
+		close(m.newBuildRequest)
 		log.Warn().Msg("Shutdown.")
 	}()
 

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -146,7 +146,7 @@ func RunBuild(reportCh chan report.Message) (map[string]*device.Device, report.S
 // StartBuildLoop starts the build in an infinite loop.
 //
 // Closing the triggerNewBuild channel will stop the loop.
-func StartBuildLoop(deviceRepo router.DevicesRepository, reports *report.Repository, triggerNewBuild <-chan bool) {
+func StartBuildLoop(deviceRepo router.DevicesRepository, reports *report.Repository, triggerNewBuild <-chan struct{}) {
 	metricsRegistry := metrics.NewRegistry()
 	for {
 		var wg sync.WaitGroup
@@ -193,8 +193,8 @@ func StartBuildLoop(deviceRepo router.DevicesRepository, reports *report.Reposit
 
 		select {
 		case <-time.After(config.Cfg.Build.Interval):
-		case c := <-triggerNewBuild:
-			if !c {
+		case _, ok := <-triggerNewBuild:
+			if !ok {
 				log.Info().Msg("triggerNewBuild channel closed, stopping build loop")
 				return
 			}

--- a/internal/job/job.go
+++ b/internal/job/job.go
@@ -144,7 +144,9 @@ func RunBuild(reportCh chan report.Message) (map[string]*device.Device, report.S
 }
 
 // StartBuildLoop starts the build in an infinite loop.
-func StartBuildLoop(deviceRepo router.DevicesRepository, reports *report.Repository) {
+//
+// Closing the triggerNewBuild channel will stop the loop.
+func StartBuildLoop(deviceRepo router.DevicesRepository, reports *report.Repository, triggerNewBuild <-chan bool) {
 	metricsRegistry := metrics.NewRegistry()
 	for {
 		var wg sync.WaitGroup
@@ -189,6 +191,13 @@ func StartBuildLoop(deviceRepo router.DevicesRepository, reports *report.Reposit
 		close(reportCh)
 		wg.Wait()
 
-		time.Sleep(config.Cfg.Build.Interval)
+		select {
+		case <-time.After(config.Cfg.Build.Interval):
+		case c := <-triggerNewBuild:
+			if !c {
+				log.Info().Msg("triggerNewBuild channel closed, stopping build loop")
+				return
+			}
+		}
 	}
 }

--- a/internal/report/report.go
+++ b/internal/report/report.go
@@ -43,7 +43,7 @@ func logMessage(msg Message) {
 // It ends when the channel is closed.
 // This function is concurrent-safe.
 func (r *Report) Watch(messageChan <-chan Message) {
-	log.Info().Msg("Starting report dispatcher")
+	log.Info().Msg("starting report dispatcher")
 	r.StartTime = time.Now()
 	for msg := range messageChan {
 		logMessage(msg)
@@ -52,7 +52,7 @@ func (r *Report) Watch(messageChan <-chan Message) {
 		r.mutex.Unlock()
 	}
 	r.EndTime = time.Now()
-	log.Info().Msg("Stopping report dispatcher")
+	log.Info().Msg("stopping report dispatcher")
 }
 
 func (r *Report) ToJSON() ([]byte, error) {


### PR DESCRIPTION
The goal is to be able to request a new build with: `POST /v1/build/trigger`.
Only one request is accepted at a time.

Bonus: closing the channels implements the graceful shutdown of a job => closing the webserver will stop the job loop.
