### PR TITLE
fix(ldap): deadlock when failed to connect to LDAP

### DIFF
--- a/internal/api/auth/ldap.go
+++ b/internal/api/auth/ldap.go
@@ -106,7 +106,6 @@ func (l *LDAPAuth) spawnConnectionWorker(ctx context.Context) {
 					conn, err = l.connect()
 					if err != nil {
 						log.Error().Err(err).Msg("worker LDAP reconnection failed")
-						req.authResp <- false
 						break
 					}
 				}


### PR DESCRIPTION
Deadlock happened when failed to reconnect to the LDAP because we send a response to the channel twice:
- line 109: once during the failure handling
- line 137: reached because of the for loop break

note: auth is false by default.