### PR TITLE
refactor: migrate back to net/http

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,6 @@ require (
 	github.com/go-ldap/ldap/v3 v3.4.8
 	github.com/go-playground/validator/v10 v10.22.0
 	github.com/google/go-cmp v0.6.0
-	github.com/julienschmidt/httprouter v1.3.0
 	github.com/openconfig/goyang v1.6.0
 	github.com/openconfig/ygot v0.29.20
 	github.com/prometheus/client_golang v1.20.1

--- a/go.sum
+++ b/go.sum
@@ -99,8 +99,6 @@ github.com/jcmturner/gokrb5/v8 v8.4.4 h1:x1Sv4HaTpepFkXbt2IkL29DXRf8sOfZXo8eRKh6
 github.com/jcmturner/gokrb5/v8 v8.4.4/go.mod h1:1btQEpgT6k+unzCwX1KdWMEwPPkkgBtP+F6aCACiMrs=
 github.com/jcmturner/rpc/v2 v2.0.3 h1:7FXXj8Ti1IaVFpSAziCZWNzbNuZmnvw/i6CqLNdWfZY=
 github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJki3ELg/Hc=
-github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
-github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/klauspost/compress v1.17.9 h1:6KIumPrER1LHsvBVuDa0r5xaG0Es51mhhB9BQB2qeMA=
 github.com/klauspost/compress v1.17.9/go.mod h1:Di0epgTjJY877eYKx5yC51cX2A2Vl2ibi7bDH9ttBbw=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=

--- a/internal/api/auth/basic_auth.go
+++ b/internal/api/auth/basic_auth.go
@@ -76,14 +76,14 @@ func (b *BasicAuth) configureLdap(ldap *LDAPAuth) error {
 func (b *BasicAuth) Wrap(next http.HandlerFunc) http.HandlerFunc {
 	switch b.mode {
 	case noAuth:
-		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) { next(w, r) })
+		return func(w http.ResponseWriter, r *http.Request) { next(w, r) }
 	case ldapMode:
 		return BasicAuthLDAP(b.ldapAuth, next)
 	default:
-		return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		return func(w http.ResponseWriter, _ *http.Request) {
 			log.Error().Str("auth-method", string(b.mode)).Str("authentication issue", "bad server configuration").Send()
 			http.Error(w, "authentication issue: bad server configuration", http.StatusInternalServerError)
-		})
+		}
 	}
 }
 

--- a/internal/api/router/endpoints.go
+++ b/internal/api/router/endpoints.go
@@ -142,7 +142,7 @@ func (m *Manager) getDeviceConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 // getLastReport returns the last or current report.
-func (m *Manager) getLastReport(w http.ResponseWriter, r *http.Request) {
+func (m *Manager) getLastReport(w http.ResponseWriter, _ *http.Request) {
 	out, err := m.reports.GetLastJSON()
 	if err != nil {
 		log.Error().Err(err).Send()
@@ -155,7 +155,7 @@ func (m *Manager) getLastReport(w http.ResponseWriter, r *http.Request) {
 }
 
 // getLastCompleteReport returns the previous build report.
-func (m *Manager) getLastCompleteReport(w http.ResponseWriter, r *http.Request) {
+func (m *Manager) getLastCompleteReport(w http.ResponseWriter, _ *http.Request) {
 	out, err := m.reports.GetLastCompleteJSON()
 	if err != nil {
 		log.Error().Err(err).Send()
@@ -168,7 +168,7 @@ func (m *Manager) getLastCompleteReport(w http.ResponseWriter, r *http.Request) 
 }
 
 // getLastSuccessfulReport returns the previous successful build report.
-func (m *Manager) getLastSuccessfulReport(w http.ResponseWriter, r *http.Request) {
+func (m *Manager) getLastSuccessfulReport(w http.ResponseWriter, _ *http.Request) {
 	out, err := m.reports.GetLastSuccessfulJSON()
 	if err != nil {
 		log.Error().Err(err).Send()
@@ -183,7 +183,7 @@ func (m *Manager) getLastSuccessfulReport(w http.ResponseWriter, r *http.Request
 // triggerBuild enables the user to trigger a new build.
 //
 // It only accepts one build request at a time.
-func (m *Manager) triggerBuild(w http.ResponseWriter, r *http.Request) {
+func (m *Manager) triggerBuild(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set(contentType, applicationJSON)
 	select {
 	case m.newBuildRequest <- struct{}{}:


### PR DESCRIPTION
There is no reason to keep using a third party lib since net/http introduced features we needed.