### PR TITLE
fix(api): auth requested even without LDAP

### DIFF
--- a/internal/api/auth/basic_auth.go
+++ b/internal/api/auth/basic_auth.go
@@ -32,7 +32,7 @@ type BasicAuth struct {
 func NewBasicAuth(ctx context.Context, cfg config.AuthConfig) (BasicAuth, error) {
 	b := BasicAuth{mode: noAuth}
 
-	if cfg.LDAP == nil {
+	if cfg.LDAP == nil || cfg.LDAP.URL == "" {
 		return b, nil
 	}
 


### PR DESCRIPTION
When LDAP is not configured, the API was still requesting a password.

Root cause: LDAP configuration has minimal config because of default settings.
Fixed by checking if the URL is set.