### PR TITLE
Fix/invalid json build response

### DIFF
--- a/internal/api/router/endpoints.go
+++ b/internal/api/router/endpoints.go
@@ -197,7 +197,7 @@ func (m *Manager) triggerBuild(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set(contentType, applicationJSON)
 	select {
 	case m.newBuildRequest <- struct{}{}:
-		_, _ = w.Write([]byte("{\"message\": \"new build request received\""))
+		_, _ = w.Write([]byte("{\"message\": \"new build request received\"}"))
 	default:
 		_, _ = w.Write([]byte("{\"message\": \"a build request is already pending\""))
 	}

--- a/internal/api/router/endpoints.go
+++ b/internal/api/router/endpoints.go
@@ -199,6 +199,6 @@ func (m *Manager) triggerBuild(w http.ResponseWriter, _ *http.Request) {
 	case m.newBuildRequest <- struct{}{}:
 		_, _ = w.Write([]byte("{\"message\": \"new build request received\"}"))
 	default:
-		_, _ = w.Write([]byte("{\"message\": \"a build request is already pending\""))
+		_, _ = w.Write([]byte("{\"message\": \"a build request is already pending\"}"))
 	}
 }


### PR DESCRIPTION
### Summary
Fix malformed JSON returned by the triggerBuild endpoint. Both response branches were missing the closing }, producing invalid JSON.